### PR TITLE
Tweak features for chrono dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ version = "1.0"
 
 [dependencies.chrono]
 version = "0.4"
+default-features = false
 
 [dependencies.hex]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,7 @@ version = "0.16"
 version = "1.3"
 
 [dependencies.x509-certificate]
-version = "0.15.0"
+git = "https://github.com/syncom/x509-certificate-rs-clone"
+# 20221117
+rev = "01a10eb4e2a243bd9cf1b6459bb59445c3071081"
 features = ["test"]


### PR DESCRIPTION
To work around a security dependency issue as discussed in https://stackoverflow.com/questions/73883691/the-latest-chrono-0-4-crate-uses-time-0-1-which-has-a-potential-segfault-how-t