### PR TITLE
GHA: upgrade actions/checkout to v4.1.1

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -12,10 +12,8 @@ jobs:
     runs-on:
       - ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v4.1.1
       - run: |
           set -euxo pipefail
+          cargo --version
           cargo build --release --all-features


### PR DESCRIPTION
Move away from the deprecated node 12.